### PR TITLE
Fix config reference

### DIFF
--- a/tasks/debug.js
+++ b/tasks/debug.js
@@ -15,12 +15,9 @@ module.exports = function(config) {
     }
     // get server config
     var proxy = {};
-    console.log('config', wpConfig);
     if (wpConfig.devServer && wpConfig.devServer.proxy) {
         proxy = wpConfig.devServer.proxy;
-        console.log('proxy', proxy);
-
-
+   
         if (!proxy['/api']) {
             proxy['/api'] = 'http://localhost:8081';
         }

--- a/tasks/debug.js
+++ b/tasks/debug.js
@@ -15,8 +15,12 @@ module.exports = function(config) {
     }
     // get server config
     var proxy = {};
-    if (config.devServer && config.devServer.proxy) {
-        proxy = config.devServer.proxy;
+    console.log('config', wpConfig);
+    if (wpConfig.devServer && wpConfig.devServer.proxy) {
+        proxy = wpConfig.devServer.proxy;
+        console.log('proxy', proxy);
+
+
         if (!proxy['/api']) {
             proxy['/api'] = 'http://localhost:8081';
         }
@@ -30,7 +34,7 @@ module.exports = function(config) {
         };
     }
     var headers = {};
-    if (config.devServer && config.devServer.headers) {
+    if (wpConfig.devServer && wpConfig.devServer.headers) {
         headers = config.devServer.headers;
     }
     // run webpack


### PR DESCRIPTION
tested proxy but not header using the following webpack config:

var path = require('path');

module.exports = {
    devtool: 'inline-source-map',
    debug: true,
    context: path.resolve(__dirname),
    entry: './src/index.js',
    output: {
        path: path.resolve(__dirname, 'dist'),
        filename: 'app.min.js',
    },
    resolve: {
        root: path.resolve(__dirname),
    },
    devServer: {
        proxy: [
            {path:'/api/*', target:'http://api-server-master.elasticbeanstalk.com'}
        ]
    }
};
